### PR TITLE
<:use 'filename'> need single quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Template subs and macros can be factored out into other template files, and
 then imported with `<:use ...>`:
 
 ```
-<:use "common.crotmp">
+<:use 'common.crotmp'>
 ```
 
 #### Inserting HTML and JavaScript


### PR DESCRIPTION
<:use 'filename'> need single quote. Double quote seems not to work.