### PR TITLE
Add missing dependency: OO::Monitors

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,8 @@
     "Jonathan Worthington <jnthn@jnthn.net>"
   ],
   "depends": [
-    "Cro::HTTP"
+    "Cro::HTTP",
+    "OO::Monitors"
   ],
   "build-depends": [],
   "test-depends": [],


### PR DESCRIPTION
It's used in `lib/Cro/WebApp/Template/Repository.pm6`.