### PR TITLE
Add :test parameter to template-location

### DIFF
--- a/lib/Cro/WebApp/Template.pm6
+++ b/lib/Cro/WebApp/Template.pm6
@@ -15,20 +15,23 @@ multi render-template(Str $template, $initial-topic --> Str) is export {
 #| Add a path to search for templates. This will be used by both the template and
 #| render-template functions. If the compile-all flag is passed, then all of the
 #| templates will be compiled up front before the function returns. Otherwise, they
-#| will be compiled on first use.
-sub template-location(IO() $location, :$compile-all --> Nil) is export {
+#| will be compiled on first use. If using compile-all, a test parameter can be set
+#| to limit the templates to compile. By default it will exclude entries whose name
+#| has a leading dot (a "hidden" file in a UNIX system). This can be overriden if
+#| necessary by setting it to *.
+sub template-location(IO() $location, :$compile-all, :$test = { .IO.basename !~~ / ^ '.' / } --> Nil) is export {
     my $template-repo = get-template-repository;
     $template-repo.add-location($location);
-    compile-dir($template-repo, $location) if $compile-all;
+    compile-dir($template-repo, $location, :$test) if $compile-all;
 }
 
-sub compile-dir(Cro::WebApp::Template::Repository $template-repo, IO::Path $location --> Nil) {
-    for dir($location) {
+sub compile-dir(Cro::WebApp::Template::Repository $template-repo, IO::Path $location, :$test --> Nil) {
+    for dir($location).grep($test) {
         when .f {
             await $template-repo.resolve-absolute($_);
         }
         when .d {
-            compile-dir($template-repo, $_);
+            compile-dir($template-repo, $_, :$test);
         }
     }
 }

--- a/t/compile-all.t
+++ b/t/compile-all.t
@@ -19,4 +19,8 @@ throws-like
         line => 3,
         'Compilation errors reported by compile-all (nested directory)';
 
+lives-ok
+        { template-location $*PROGRAM.parent.add('compile-all-error-deep'), :compile-all, test => { $_ !~~ / 'broken' | 'problem' / } },
+        'Can ignore files';
+
 done-testing;


### PR DESCRIPTION
This patch adds a `test` parameter to be passed to template-location that works in a similar way to the parameter of the same name for [dir].

By default, this will be set to ignore files and directories whose basename has a leaing period (hidden files in UNIX systems).
This change in behaviour makes it so that, for example, working in a cro project with an editor that ordinarily creates hidden swap files (like vim) will not make this function automatically die with a hard-to-understand error about malformed UTF-8 characters.

This is a change in behaviour, but it is unlikely that the old behaviour was expected. Users that do want to match _all_ files
can, like with the [dir] routine, set this to `*`.

This parameter only takes effect if the `compile-all` flag is set.

[dir]: https://docs.raku.org/routine/dir