### PR TITLE
Implement template parts

### DIFF
--- a/lib/Cro/WebApp/Template.pm6
+++ b/lib/Cro/WebApp/Template.pm6
@@ -12,6 +12,10 @@ my class TemplateResourcesLocation {
     has Str $.prefix is required;
 }
 
+# Another router plugin is used for data providers for template parts. This will
+# will have a hash per route block, mapping part names into providers.
+my $template-part-plugin = router-plugin-register("template-part");
+
 #| Render the template at the specified path using the specified data, and
 #| return the result as a C<Str>.
 multi render-template(IO::Path $template-path, $initial-topic, :%parts --> Str) is export {
@@ -113,10 +117,73 @@ sub templates-from-resources(:$prefix = '' --> Nil) is export {
             error-sub => 'templates-from-resources';
 }
 
+#| Thrown when a template part provider is registered in a C<route> block that
+#| is identical to an existing part provider for the same name.
+class X::Cro::WebApp::Template::DuplicatePartProvider is Exception {
+    has Str $.name is required;
+    method message() {
+        "Duplicate template-part provider for '$!name'"
+    }
+}
+
+#| Thrown when a part provider has an unsupported signature (anything other than a
+#| single authorization parameter is reserved).
+class X::Cro::WebApp::Template::BadPartProviderParameters is Exception {
+    method message() {
+        "A template-part provider should have either no parameters or a single parameter of type Cro::HTTP::Auth or marked with the `is auth` trait"
+    }
+}
+
+#| Specify a data provider for a template part. Parts are typically used for
+#| common page elements that appear on all or many pages and need some data.
+#| For example, a page header may wish to show the name of the currently logged
+#| in user. The part provider may either take zero or one arguments; the one
+#| argument must either be of type C<Cro::HTTP::Auth> or marked with the `is auth`
+#| trait, and will be passed the value of `request.auth` so long as it matches
+#| any type constraint. This allows, for example, writing different providers for
+#| logged in and not logged in users.
+sub template-part(Str $name, &provider --> Nil) is export {
+    # We use a hash per route block to store the parts that it contributes.
+    my @current-configs = router-plugin-get-innermost-configs($template-part-plugin);
+    my %parts := do if @current-configs {
+        @current-configs[0]
+    }
+    else {
+        my Array %new-hash;
+        router-plugin-add-config($template-part-plugin, %new-hash);
+        %new-hash
+    }
+
+    # It must be either zero arity or arity one but expecting a Cro::Auth of
+    # some kind.
+    my $signature = &provider.signature;
+    if $signature.arity == 1 {
+        my Parameter $param = $signature.params[0];
+        unless $param ~~ Cro::HTTP::Router::Auth || $param.type ~~ Cro::HTTP::Auth {
+            die X::Cro::WebApp::Template::BadPartProviderParameters.new;
+        }
+    }
+    elsif $signature.arity > 1 {
+        die X::Cro::WebApp::Template::BadPartProviderParameters.new;
+    }
+
+    # Detect conflicts. It is allowed to have multiple so long as they have
+    # distinct signatures.
+    if %parts{$name} -> @existing {
+        if any(@existing).signature eqv $signature {
+            die X::Cro::WebApp::Template::DuplicatePartProvider.new(:$name);
+        }
+    }
+
+    # All is well, so add the part.
+    %parts{$name}.push(&provider);
+}
+
 #| Used in a Cro::HTTP::Router route handler to render a template and set it as
 #| the response body. The initial topic is passed to the template to render. The
 #| content type will default to text/html, but can be set explicitly also.
 multi template($template, $initial-topic, :%parts, :$content-type = 'text/html' --> Nil) is export {
+    my @*CRO-TEMPLATE-PART-PROVIDERS := router-plugin-get-configs($template-part-plugin, error-sub => 'template');
     content $content-type, render-template($template, $initial-topic, :%parts);
 }
 

--- a/lib/Cro/WebApp/Template/ASTBuilder.pm6
+++ b/lib/Cro/WebApp/Template/ASTBuilder.pm6
@@ -120,6 +120,15 @@ class Cro::WebApp::Template::ASTBuilder {
         make MacroBody.new;
     }
 
+    method sigil-tag:sym<part>($/) {
+        make TemplatePart.new:
+                name => ~$<name>,
+                parameters => $<signature> ?? $<signature>.ast !! (),
+                children => flatten-literals($<sequence-element>.map(*.ast),
+                        :trim-trailing-horizontal($*lone-end-line)),
+                trim-trailing-horizontal-before => $*lone-start-line;
+    }
+
     method sigil-tag:sym<use>($/) {
         with $<file> {
             my $template-name = .ast;

--- a/lib/Cro/WebApp/Template/Parser.pm6
+++ b/lib/Cro/WebApp/Template/Parser.pm6
@@ -182,6 +182,27 @@ grammar Cro::WebApp::Template::Parser {
         '<:body' \h* '>'
     }
 
+    token sigil-tag:sym<part> {
+        :my $opener = $¢.clone;
+        :my $*lone-start-line = False;
+        '<:part'
+        [ <?after [^ | $ | \n] \h* '<:part'> { $*lone-start-line = True } ]?
+        \h+
+        [
+        || <name=.identifier> \h* <signature>? '>'
+        || <.malformed: 'part declaration tag'>
+        ]
+        [ <?{ $*lone-start-line }> [ \h* \n | { $*lone-start-line = False } ] ]?
+
+        <sequence-element>*
+
+        :my $*lone-end-line = False;
+        [ '</:' || { $opener.unclosed('part declaration tag') } ]
+        [ <?after \n \h* '</:'> { $*lone-end-line = True } ]?
+        [ 'part'? \h* '>' || <.malformed: 'part declaration closing tag'> ]
+        [ <?{ $*lone-end-line }> [ \h* \n | { $*lone-end-line = False } ] ]?
+    }
+
     token sigil-tag:sym<apply> {
         :my $*lone-start-line = False;
         '<|'

--- a/t/template-parts.t
+++ b/t/template-parts.t
@@ -1,0 +1,32 @@
+use Cro::WebApp::Template;
+use Test;
+
+my constant $base = $*PROGRAM.parent.add('test-data');
+
+is render-template($base.add('parts-simple.crotmp'), {}, :parts{ header => \('dave') }),
+        q:to/EXPECTED/, 'Can render a part with an explicit capture (value provided)';
+    Before part
+        User dave is logged in
+    After part
+    EXPECTED
+
+is render-template($base.add('parts-simple.crotmp'), {}, :parts{ header => \(Nil) }),
+        q:to/EXPECTED/, 'Can render a part with an explicit capture (undefined value provided)';
+    Before part
+        Not logged in
+    After part
+    EXPECTED
+
+is render-template($base.add('parts-simple.crotmp'), {}, :parts{ header => 'dave' }),
+        q:to/EXPECTED/, 'When the part value is a single value it becomes one argument';
+    Before part
+        User dave is logged in
+    After part
+    EXPECTED
+
+is render-template($base.add('parts-main.crotmp'), \(:greeting<ahoj>, :name<dave>)),
+        q:to/EXPECTED/, 'The MAIN part gets the initial topic (catpure case)';
+      ahoj, dave!
+    EXPECTED
+
+done-testing;

--- a/t/template-parts.t
+++ b/t/template-parts.t
@@ -29,4 +29,11 @@ is render-template($base.add('parts-main.crotmp'), \(:greeting<ahoj>, :name<dave
       ahoj, dave!
     EXPECTED
 
+template-location $*PROGRAM.parent.add('test-data');
+is render-template($base.add('parts-use.crotmp'), {}, :parts{ header => 'ann' }).trim,
+        q:to/EXPECTED/.trim, 'Correct interaction of parts, macros, and use';
+        Logged in as ann
+        Hello world
+    EXPECTED
+
 done-testing;

--- a/t/test-data/parts-layout.crotmp
+++ b/t/test-data/parts-layout.crotmp
@@ -1,0 +1,8 @@
+<:macro layout>
+  <:part header($user)>
+    <?$user>
+      Logged in as <$user>
+    </?>
+  </:>
+  <:body>
+</:macro>

--- a/t/test-data/parts-main.crotmp
+++ b/t/test-data/parts-main.crotmp
@@ -1,0 +1,3 @@
+<:part MAIN(:$greeting, :$name)>
+  <$greeting>, <$name>!
+</:>

--- a/t/test-data/parts-simple.crotmp
+++ b/t/test-data/parts-simple.crotmp
@@ -1,0 +1,10 @@
+Before part
+<:part header($user)>
+  <?$user>
+    User <$user> is logged in
+  </?>
+  <!$user>
+    Not logged in
+  </!>
+</:>
+After part

--- a/t/test-data/parts-use.crotmp
+++ b/t/test-data/parts-use.crotmp
@@ -1,0 +1,4 @@
+<:use 'parts-layout.crotmp'>
+<|layout>
+  Hello world
+</|>


### PR DESCRIPTION
Template parts are being introduced primarily to ease the common situation where we have sections of a page that need some data to be rendered, and it is inconvenient to pass that in with every call to `template`. For example, every page may feature an indication of shopping cart size or the name of the currently logged in user in the header.

The special part name `MAIN` can be used to access the top-level data, which is set as the topic in the template by default. This opens up an alternative pattern for writing more complex templates: pass a `Capture` as the template data, and have the arguments bound into the `MAIN` part's parameters.

The part data provider in the template may receive the current `request.auth` as an argument, and also constrain it, so one could have different part providers for logged in or not logged in, or really any other property reachable via the current `auth` (which may be a user, a session, etc.)