### PR TITLE
Present the simplest way to handle comments

### DIFF
--- a/lib/Cro/WebApp/Template/Parser.pm6
+++ b/lib/Cro/WebApp/Template/Parser.pm6
@@ -55,7 +55,8 @@ grammar Cro::WebApp::Template::Parser {
     }
 
     token tag-element:sym<literal> {
-        <-[<>]>+
+        | '!--' .*? '--' <?before '>'>
+        | <-[<>]>+
     }
 
     proto token sigil-tag { * }

--- a/t/template-basic.t
+++ b/t/template-basic.t
@@ -221,10 +221,15 @@ is norm-ws(render-template($base.add('comments.crotmp'), {})),
     <!-- HTML comment -->
     <div>Something else</div>
     <!--
-        multi-line HTML comment
+        multi-line HTML--comment
         -->
     <p>And that's it<!--really--></p>
     EXPECTED
+
+is norm-ws(render-template($base.add('comments-integration.crotmp'), {})),
+        norm-ws(q:to/EXPECTED/), 'Is not confused by HTML bits commented out';
+<html><!--<articleclass="messageis-small"><divclass="message--body">--><!--</div></article>--></html>
+EXPECTED
 
 sub norm-ws($str) {
     $str.subst(:g, /\s+/, '')

--- a/t/test-data/comments-integration.crotmp
+++ b/t/test-data/comments-integration.crotmp
@@ -1,0 +1,6 @@
+<html>
+                      <!--<article class="message is-small">
+                        <div class="message--body">-->
+                        <!--</div>
+                      </article>-->
+</html>

--- a/t/test-data/comments.crotmp
+++ b/t/test-data/comments.crotmp
@@ -2,6 +2,6 @@
 <!-- HTML comment -->
 <div>Something else</div>
 <!--
-    multi-line HTML comment
+    multi-line HTML -- comment
     -->
 <p>And that's it<!--really--></p>


### PR DESCRIPTION
Do not rely on considering things that are not `<` and `>` being literals,
instead provide an alternative to parse "-- everything non-greedy before closing `-->`" after
the opener `<`.

Closes https://github.com/croservices/cro-webapp/issues/45