### PR TITLE
Allow forms to be rendered with non-post methods

### DIFF
--- a/resources/prelude.crotmp
+++ b/resources/prelude.crotmp
@@ -21,12 +21,12 @@
   </?>
 </:>
 
-<:sub form-errors($_, :$form-errors-class, :$form-errors-text)>
-  <?.HTML-RENDER-DATA.<validation-errors>>
+<:sub form-errors($_, :$form-errors-class, :$form-errors-text, :$method)>
+  <?.HTML-RENDER-DATA(:$method).<validation-errors>>
     <div<&class($form-errors-class)>>
       <?$form-errors-text><$form-errors-text></?>
       <ul>
-        <@HTML-RENDER-DATA.<validation-errors>>
+        <@HTML-RENDER-DATA(:$method).<validation-errors>>
           <li><$_></li>
         </@>
       </ul>
@@ -39,10 +39,10 @@
                :$novalidate, :$was-validated-class, :$is-invalid-class,
                :$invalid-feedback-class, :$form-errors-class, :$form-errors-text,
                :$help-class, :$submit-button-class, :$submit-button-text,
-               :$action, :$name)>
-  <form name="<?$name><$name></?><!$name><.GENERATE-NAME></!>" method="post"<?$action> action="<$action>"</?><?$novalidate> novalidate</?><?{ .<was-validated> && $was-validated-class }> class="<$was-validated-class>"</?><?.HTML-RENDER-DATA.enctype> enctype="<.HTML-RENDER-DATA.enctype>"</?>>
-  <&form-errors($_, :$form-errors-class, :$form-errors-text)>
-  <@HTML-RENDER-DATA.controls>
+               :$action, :$name, :$method = 'post')>
+  <form name="<?$name><$name></?><!$name><.GENERATE-NAME></!>" method="<$method>"<?$action> action="<$action>"</?><?$novalidate> novalidate</?><?{ .<was-validated> && $was-validated-class }> class="<$was-validated-class>"</?><?.HTML-RENDER-DATA(:$method).enctype> enctype="<.HTML-RENDER-DATA(:$method).enctype>"</?>>
+  <&form-errors($_, :$form-errors-class, :$form-errors-text, :$method)>
+  <@HTML-RENDER-DATA(:$method).controls>
     <?{ .type eq 'text' || .type eq 'email' || .type eq 'search' || .type eq 'url' || .type eq 'tel' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>

--- a/t/form-get.t
+++ b/t/form-get.t
@@ -1,0 +1,21 @@
+use Cro::WebApp::Form;
+use Cro::WebApp::Template::Repository;
+use Test;
+
+class Search does Cro::WebApp::Form { has $.query is search }
+class Upload does Cro::WebApp::Form { has $.photo is file   }
+
+constant template = parse-template ｢<&form($_, :method('get'))>｣;
+
+with template.render: Search.empty {
+    like $_, / 'method="get"' /, 'Form method is GET';
+
+    unlike $_, / '__CSRF_TOKEN' /, 'CSRF token is omitted';
+}
+
+throws-like { template.render: Upload.empty },
+    X::Cro::WebApp::Form::FileInGET,
+    :message("Form 'Upload' cannot contain element 'photo' with 'GET' method"),
+    'File element in a GET form dies';
+
+done-testing;


### PR DESCRIPTION
I'd like to be able to use `Cro::WebApp::Form` for an advanced search route but the render sub is currently hardcoded to do a POST request, this PR changes that.

I'm not sure if this is the right way to go about this, but it seems like the simplest approach.