### PR TITLE
Currently, DateTime fields of Raku are not displayed properly in ::WebApp::Forms

### DIFF
--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -489,21 +489,21 @@ role Cro::WebApp::Form {
             when Date { %properties<value> = .yyyy-mm-dd; }
 
             when DateTime {
-                # Fractional seconds and Timezone must be dropped for
-                # datetime-local form element, or the value will not be
-                # displayed.
-                #
-                # This means that:
-                #   YYYY-MM-DDTHH:MM:SS.SSS-0000
-                # Has to become:
-                #  YYYY-MM-DDTHH:MM:SS
-                my $ts = .Str;
-                unless $ts.ends-with('Z') {
-                  my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
-                  my $i  = $ts.chars - $cutoff;
-                  $ts .= substr(0, * - $i);
-                }
-                %properties<value> = $ts;
+                  # Fractional seconds and Timezone must be dropped for
+                  # datetime-local form element, or the value will not be
+                  # displayed.
+                  #
+                  # This means that:
+                  #   YYYY-MM-DDTHH:MM:SS.SSS-0000
+                  # Has to become:
+                  #  YYYY-MM-DDTHH:MM:SS
+                  my $ts = .Str;
+                  unless $ts.ends-with('Z') {
+                    my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
+                    my $i  = $ts.chars - $cutoff;
+                    $ts .= substr(0, * - $i);
+                  }
+                  %properties<value> = $ts;
             }
 
             default { %properties<value> = $_; }

--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -487,7 +487,23 @@ role Cro::WebApp::Form {
     method !add-current-value(Attribute $attr, %properties? is copy) {
         with $attr.get_value(self) {
             when Date { %properties<value> = .yyyy-mm-dd; }
-            when DateTime { %properties<value> = .Str; }
+
+            when DateTime {
+                # Fractional seconds and Timezone must be dropped for
+                # datetime-local form element, or the value will not be
+                # displayed.
+                #
+                # This means that:
+                #   YYYY-MM-DDTHH:MM:SS.SSS-0000
+                # Has to become:
+                #  YYYY-MM-DDTHH:MM:SS
+                my $ts = .Str;
+                my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
+                my $i  = $ts.chars - $cutoff;
+                $ts .= substr(0, * - $i);
+                %properties<value> = $ts;
+            }
+
             default { %properties<value> = $_; }
         }
         orwith %!unparseable{$attr.name.substr(2)} {

--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -489,21 +489,21 @@ role Cro::WebApp::Form {
             when Date { %properties<value> = .yyyy-mm-dd; }
 
             when DateTime {
-                  # Fractional seconds and Timezone must be dropped for
-                  # datetime-local form element, or the value will not be
-                  # displayed.
-                  #
-                  # This means that:
-                  #   YYYY-MM-DDTHH:MM:SS.SSS-0000
-                  # Has to become:
-                  #  YYYY-MM-DDTHH:MM:SS
-                  my $ts = .Str;
-                  unless $ts.ends-with('Z') {
+                # Fractional seconds and Timezone must be dropped for
+                # datetime-local form element, or the value will not be
+                # displayed.
+                #
+                # This means that:
+                #   YYYY-MM-DDTHH:MM:SS.SSS-0000
+                # Has to become:
+                #  YYYY-MM-DDTHH:MM:SS
+                my $ts = .Str;
+                unless $ts.ends-with('Z') {
                     my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
                     my $i  = $ts.chars - $cutoff;
                     $ts .= substr(0, * - $i);
-                  }
-                  %properties<value> = $ts;
+                }
+                %properties<value> = $ts;
             }
 
             default { %properties<value> = $_; }

--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -498,9 +498,11 @@ role Cro::WebApp::Form {
                 # Has to become:
                 #  YYYY-MM-DDTHH:MM:SS
                 my $ts = .Str;
-                my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
-                my $i  = $ts.chars - $cutoff;
-                $ts .= substr(0, * - $i);
+                unless $ts.ends-with('Z') {
+                  my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
+                  my $i  = $ts.chars - $cutoff;
+                  $ts .= substr(0, * - $i);
+                }
                 %properties<value> = $ts;
             }
 

--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -498,7 +498,9 @@ role Cro::WebApp::Form {
                 # Has to become:
                 #  YYYY-MM-DDTHH:MM:SS
                 my $ts = .Str;
-                unless $ts.ends-with('Z') {
+                if $ts.ends-with('Z') {
+                    $ts ~~ / '.' \d+? 'Z' /Z/;
+                } else {
                     my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
                     my $i  = $ts.chars - $cutoff;
                     $ts .= substr(0, * - $i);

--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -499,7 +499,7 @@ role Cro::WebApp::Form {
                 #  YYYY-MM-DDTHH:MM:SS
                 my $ts = .Str;
                 if $ts.ends-with('Z') {
-                    $ts ~~ / '.' \d+? 'Z' /Z/;
+                    $ts ~~ s/ '.' \d+? 'Z' /Z/;
                 } else {
                     my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
                     my $i  = $ts.chars - $cutoff;

--- a/t/form-render.t
+++ b/t/form-render.t
@@ -209,6 +209,26 @@ use Test;
                 ]
             },
             'Form with DateTime type attribute renders a datetime-local control';
+
+    my $dt = DateTime.now.utc;
+    my $formatted-now = sprintf(
+        '%4d-%02d-%02dT%02d:%02d:%02dZ',
+        .year, .month, .day, .hour, .minute, .second
+    ) given $dt;
+    is-deeply DateTimeForm.new(when => $dt).HTML-RENDER-DATA,
+            {
+                was-validated => False,
+                controls => [
+                    {
+                        type => 'datetime-local',
+                        name => 'when',
+                        label => 'When',
+                        required => True,
+                        value => $formatted-now
+                    },
+                ]
+            },
+            'Form with DateTime.utc type attribute renders a datetime-local control';
 }
 
 {


### PR DESCRIPTION
Fractional seconds and Timezone must be dropped for
datetime-local form element, or the value will not be
displayed.

This means that:
   YYYY-MM-DDTHH:MM:SS.SSS-0000
Has to become:
   YYYY-MM-DDTHH:MM:SS

This commit addresses the issue.