### PR TITLE
- Fixes application of "selected" attribute on <option> tags.

### DIFF
--- a/lib/Cro/WebApp/Form.pm6
+++ b/lib/Cro/WebApp/Form.pm6
@@ -527,7 +527,7 @@ role Cro::WebApp::Form {
             else {
                 $key = $value = $opt;
             }
-            $value (elem) @current ?? ($key, $value, True) !! ($key, $value)
+            $key (elem) @current ?? ($key, $value, True) !! ($key, $value)
         }]
     }
 


### PR DESCRIPTION
Since it is not the $value that needs comparison in the case when a Pair is used but the $key, since that is the value returned to the server.