### PR TITLE
Silence some warnings in escaping

### DIFF
--- a/lib/Cro/WebApp/Template/AST.pm6
+++ b/lib/Cro/WebApp/Template/AST.pm6
@@ -318,11 +318,23 @@ my constant %escapes = %(
     "'" => '&apos;',
 );
 
-sub escape-text(Str() $text) {
+proto sub escape-text(|) { * }
+
+multi sub escape-text(Any:U --> Str ) {
+    ''
+}
+
+multi sub escape-text(Str:D() $text) {
     $text.subst(/<[<>&]>/, { %escapes{.Str} }, :g)
 }
 
-sub escape-attribute(Str() $attr) {
+proto sub escape-attribute(|) { * }
+
+multi sub escape-attribute(Any:U --> Str ) {
+    ''
+}
+
+multi sub escape-attribute(Str:D() $attr) {
     $attr.subst(/<[&"']>/, { %escapes{.Str} }, :g)
 }
 


### PR DESCRIPTION
If the object passed to the template has undefined keys (or methods that return Nil,) then there were warnings produced from the escaping. For an Associative this could potentially be worked around at source, but for an object that has methods that may return Nil ( say an ORM row object,) it's a bit less tractable.