### PR TITLE
Provide for iteration with a separator

### DIFF
--- a/lib/Cro/WebApp/Template/AST.pm6
+++ b/lib/Cro/WebApp/Template/AST.pm6
@@ -120,14 +120,22 @@ my class HashKeyDeref does Node is export {
     }
 }
 
+my class Separator does ContainerNode is export {
+    method compile() {
+        '(' ~ @!children.map(*.compile).join(", ") ~ ').join'
+    }
+}
+
 my class Iteration does ContainerNode is export {
     has Node $.target is required;
+    has Separator $.separator;
     has $.iteration-variable;
 
     method compile() {
         my $variable = $!iteration-variable.?name // '$_';
         my $children-compiled = @!children.map(*.compile).join(", ");
-        '(' ~ $!target.compile ~ ').map(-> ' ~ $variable  ~ ' { join "", (' ~ $children-compiled ~ ') }).join'
+        '(' ~ $!target.compile ~ ').map(-> ' ~ $variable  ~ ' { join "", (' ~ $children-compiled ~ ') }).join' ~
+                ($!separator ?? '(' ~ $!separator.compile() ~ ')' !! '')
     }
 }
 
@@ -311,6 +319,12 @@ my class EscapeAttribute does Node is export {
 
     method compile() {
         'escape-attribute(' ~ $!target.compile() ~ ", '$!filename.Str()', $!line)";
+    }
+}
+
+my class Nothing does Node is export {
+    method compile() {
+        "''"
     }
 }
 

--- a/lib/Cro/WebApp/Template/ASTBuilder.pm6
+++ b/lib/Cro/WebApp/Template/ASTBuilder.pm6
@@ -95,10 +95,18 @@ class Cro::WebApp::Template::ASTBuilder {
         }
         my $iteration-variable = $<iteration-variable>.ast;
         make Iteration.new:
-            :$target,  :$iteration-variable,
+            :$target,  :$iteration-variable, :separator($*SEPARATOR // Separator),
             children => flatten-literals($<sequence-element>.map(*.ast),
                 :trim-trailing-horizontal($*lone-end-line)),
             trim-trailing-horizontal-before => $*lone-start-line;
+    }
+
+    method sigil-tag:sym<separator>($/) {
+        $*SEPARATOR = Separator.new:
+                children => flatten-literals($<sequence-element>.map(*.ast),
+                        :trim-trailing-horizontal($*lone-end-line)),
+                trim-trailing-horizontal-before => $*lone-start-line;
+        make Nothing.new;
     }
 
     method sigil-tag:sym<condition>($/) {

--- a/t/error-data/duplicate-separator.crotmp
+++ b/t/error-data/duplicate-separator.crotmp
@@ -1,0 +1,5 @@
+<@things>
+  <$_>
+  <:separator><hr></:>
+  <:separator><hr></:>
+</@>

--- a/t/error-data/misplaced-separator.crotmp
+++ b/t/error-data/misplaced-separator.crotmp
@@ -1,0 +1,4 @@
+<?.foo>
+  bar
+  <:separator><hr /></:>
+</?>

--- a/t/template-iterator.t
+++ b/t/template-iterator.t
@@ -2,6 +2,7 @@ use Cro::WebApp::Template;
 use Test;
 
 my constant $base = $*PROGRAM.parent.add('test-data');
+my constant $error-base = $*PROGRAM.parent.add('error-data');
 
 is norm-ws(render-template($base.add('iteration-2.crotmp'), %{ countries => [
                 { name => 'Argentina', alpha2 => 'AR' },
@@ -56,5 +57,22 @@ is norm-ws(render-template($base.add('iteration-5.crotmp'), %{ countries => [
         <option value="CZ">Czech Republic</option>
     </select>
     EXPECTED
+
+is norm-ws(render-template($base.add('iteration-6.crotmp'), { :things['foo', 'bar', 'baz'] })),
+        norm-ws(q:to/EXPECTED/), 'Separator syntax works';
+    foo
+    <hr>
+    bar
+    <hr>
+    baz
+    EXPECTED
+
+throws-like { render-template($error-base.add('misplaced-separator.crotmp'), {}) },
+        X::Cro::WebApp::Template::SyntaxError,
+        'Can only use separator inside of iteration';
+
+throws-like { render-template($error-base.add('duplicate-separator.crotmp'), {}) },
+        X::Cro::WebApp::Template::SyntaxError,
+        'Can only have one separator';
 
 done-testing;

--- a/t/test-data/iteration-6.crotmp
+++ b/t/test-data/iteration-6.crotmp
@@ -1,0 +1,4 @@
+<@things>
+  <$_>
+  <:separator><hr></:>
+</@>


### PR DESCRIPTION
Resolves #47, which requested a way to do an iteration with a separator
that goes between the items. Given this is a relatively common need and
there's no easy way to do it otherwise, we add this way to do it.