### PR TITLE
Crash hardening against missing %*WARNINGS var.

### DIFF
--- a/lib/Cro/WebApp/Template/AST.rakumod
+++ b/lib/Cro/WebApp/Template/AST.rakumod
@@ -347,7 +347,8 @@ my constant %escapes = %(
 );
 
 multi escape-text(Mu:U $t, Mu $file, Mu $line) {
-    %*WARNINGS{"An expression at $file:$line evaluated to $t.^name()"}++;
+    %*WARNINGS{"An expression at $file:$line evaluated to $t.^name()"}++
+        if DYNAMIC::<%*WARNINGS>;
     ''
 }
 


### PR DESCRIPTION
This can occur when encountering Nil values in template variables.