### PR TITLE
Fix date generation

### DIFF
--- a/lib/Cro/WebApp/Form.rakumod
+++ b/lib/Cro/WebApp/Form.rakumod
@@ -523,7 +523,7 @@ role Cro::WebApp::Form {
                 #  YYYY-MM-DDTHH:MM:SS
                 my $ts = .Str;
                 if $ts.ends-with('Z') {
-                    $ts ~~ s/ '.' \d+? 'Z' /Z/;
+                    $ts ~~ s/ ['.' \d+?]? 'Z' //;
                 } else {
                     my $cutoff = $ts.rindex(".") // $ts.rindex("-") // $ts.rindex("+");
                     my $i  = $ts.chars - $cutoff;

--- a/t/form-render.rakutest
+++ b/t/form-render.rakutest
@@ -204,7 +204,7 @@ use Test;
                         name => 'when',
                         label => 'When',
                         required => True,
-                        value => '2020-12-25T10:00:00Z',
+                        value => '2020-12-25T10:00:00',
                     },
                 ]
             },
@@ -212,7 +212,7 @@ use Test;
 
     my $dt = DateTime.now.utc;
     my $formatted-now = sprintf(
-        '%4d-%02d-%02dT%02d:%02d:%02dZ',
+        '%4d-%02d-%02dT%02d:%02d:%02d',
         .year, .month, .day, .hour, .minute, .second
     ) given $dt;
     is-deeply DateTimeForm.new(when => $dt).HTML-RENDER-DATA,


### PR DESCRIPTION
datetime-local form element does not like values ending in 'Z'. Thus we drop it.

Thanks to Xliff for the original PR that is salvaged here.