### PR TITLE
add template-inline

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,39 +1,37 @@
 {
-  "name": "Cro::WebApp",
-  "description": "Support for building server-side web applications with Cro, including templates and form handling.",
-  "version": "0.8.9.1",
-  "perl": "6.*",
-  "authors": [
-    "Jonathan Worthington <jnthn@jnthn.net>"
-  ],
-  "auth": "zef:cro",
-  "depends": [
-    "Cro::HTTP:ver<0.8.9>",
-    "Log::Timeline",
-    "OO::Monitors"
-  ],
-  "build-depends": [],
-  "test-depends": [],
-  "provides": {
-    "Cro::WebApp::Form": "lib/Cro/WebApp/Form.rakumod",
-    "Cro::WebApp::LogTimelineSchema": "lib/Cro/WebApp/LogTimelineSchema.rakumod",
-    "Cro::WebApp::Template": "lib/Cro/WebApp/Template.rakumod",
-    "Cro::WebApp::Template::AST": "lib/Cro/WebApp/Template/AST.rakumod",
-    "Cro::WebApp::Template::ASTBuilder": "lib/Cro/WebApp/Template/ASTBuilder.rakumod",
-    "Cro::WebApp::Template::Builtins": "lib/Cro/WebApp/Template/Builtins.rakumod",
-    "Cro::WebApp::Template::Error": "lib/Cro/WebApp/Template/Error.rakumod",
-    "Cro::WebApp::Template::Library": "lib/Cro/WebApp/Template/Library.rakumod",
-    "Cro::WebApp::Template::Location": "lib/Cro/WebApp/Template/Location.rakumod",
-    "Cro::WebApp::Template::Parser": "lib/Cro/WebApp/Template/Parser.rakumod",
-    "Cro::WebApp::Template::Repository": "lib/Cro/WebApp/Template/Repository.rakumod"
-  },
-  "resources": [
-    "prelude.crotmp"
-  ],
-  "license": "Artistic-2.0",
-  "tags": [
-    "template",
-    "web"
-  ],
-  "source-url": "https://github.com/croservices/cro-webapp.git"
+    "name": "Cro::WebApp",
+    "description": "Support for building server-side web applications with Cro, including templates and form handling.",
+    "version": "0.8.9.1",
+    "authors": [
+        "Jonathan Worthington <jnthn@jnthn.net>"
+    ],
+    "auth": "zef:cro",
+    "depends": [
+        "Cro::HTTP:ver<0.8.9>",
+        "Log::Timeline",
+        "OO::Monitors"
+    ],
+    "build-depends": [],
+    "provides": {
+        "Cro::WebApp::Form": "lib/Cro/WebApp/Form.rakumod",
+        "Cro::WebApp::LogTimelineSchema": "lib/Cro/WebApp/LogTimelineSchema.rakumod",
+        "Cro::WebApp::Template": "lib/Cro/WebApp/Template.rakumod",
+        "Cro::WebApp::Template::AST": "lib/Cro/WebApp/Template/AST.rakumod",
+        "Cro::WebApp::Template::ASTBuilder": "lib/Cro/WebApp/Template/ASTBuilder.rakumod",
+        "Cro::WebApp::Template::Builtins": "lib/Cro/WebApp/Template/Builtins.rakumod",
+        "Cro::WebApp::Template::Error": "lib/Cro/WebApp/Template/Error.rakumod",
+        "Cro::WebApp::Template::Library": "lib/Cro/WebApp/Template/Library.rakumod",
+        "Cro::WebApp::Template::Location": "lib/Cro/WebApp/Template/Location.rakumod",
+        "Cro::WebApp::Template::Parser": "lib/Cro/WebApp/Template/Parser.rakumod",
+        "Cro::WebApp::Template::Repository": "lib/Cro/WebApp/Template/Repository.rakumod"
+    },
+    "resources": [
+        "prelude.crotmp"
+    ],
+    "license": "Artistic-2.0",
+    "tags": [
+        "template",
+        "web"
+    ],
+    "source-url": "https://github.com/croservices/cro-webapp.git"
 }

--- a/lib/Cro/WebApp/Template.rakumod
+++ b/lib/Cro/WebApp/Template.rakumod
@@ -204,3 +204,10 @@ multi template($template, $initial-topic, :%parts, :$content-type = 'text/html',
 multi template($template, :%parts, :$content-type = 'text/html', :$fragment --> Nil) is export {
     template($template, Nil, :%parts, :$content-type, :$fragment);
 }
+
+#| Used in a Cro::HTTP::Router route handler to render a template inline from
+#| a source Str. The initial topic is then passed to the template to render. The
+#| content type will default to text/html, but can be set explicitly also.
+sub template-inline($source, $initial-topic, :%parts, :$content-type = 'text/html', :$fragment --> Nil) is export {
+    content $content-type, parse-template($source).render($initial-topic, :%parts, :$fragment);
+}

--- a/t/template-parse-from-source.rakutest
+++ b/t/template-parse-from-source.rakutest
@@ -1,6 +1,8 @@
 use Test;
 use Cro::WebApp::Template::Repository;
 
+#| template-inline() is not amenable to direct testing since
+#| Can only use 'content' inside of a request handler
 my Cro::WebApp::Template::Compiled $parsed;
 lives-ok { $parsed = parse-template('<.foo>, <.bar>') },
         'Can parse a template from a string';


### PR DESCRIPTION
This is proposed as a small feature for extending the facility of templates to be assembled within route blocks for HTML::Components.

Is resolves issue #94