### PR TITLE
Add required attr to input tags

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Cro::WebApp
 
+{{$NEXT}}
+    - Add the 'required' attr to input tags
+
 0.10.0
     - Allow templates to be assembled within route blocks for HTML::Components.
 

--- a/resources/prelude.crotmp
+++ b/resources/prelude.crotmp
@@ -46,7 +46,7 @@
     <?{ .type eq 'text' || .type eq 'email' || .type eq 'search' || .type eq 'url' || .type eq 'tel' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <input type="<.type>" name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)><&str-opts($_)><?.<value>.defined()> value="<.value>"</?>>
+        <input type="<.type>" name="<.name>" id="<.name>" <?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)><&str-opts($_)><?.<value>.defined()> value="<.value>"</?>>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -54,7 +54,7 @@
     <?{ .type eq 'file' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <input type="<.type>" name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)><&str-opts($_)>>
+        <input type="<.type>" name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)><&str-opts($_)>>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -62,7 +62,7 @@
     <?{ .type eq 'number' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <input type="number" name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)><&num-opts($_)><?.<value>.defined()> value="<.value>"</?>>
+        <input type="number" name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)><&num-opts($_)><?.<value>.defined()> value="<.value>"</?>>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -70,7 +70,7 @@
     <?{ .type eq 'color' || .type eq 'date' || .type eq 'datetime-local' || .type eq 'month' || .type eq 'time' || .type eq 'week' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <input type="<.type>" name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)><?.<value>.defined()> value="<.value>"</?>>
+        <input type="<.type>" name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)><?.<value>.defined()> value="<.value>"</?>>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -78,7 +78,7 @@
     <?{ .type eq 'password' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <input type="password" name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)>>
+        <input type="password" name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)>>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -86,7 +86,7 @@
     <?{ .type eq 'textarea' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <textarea name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)><&rows-cols(.rows, .cols)><&str-opts($_)>><?.<value>.defined()><.value></?></textarea>
+        <textarea name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)><&rows-cols(.rows, .cols)><&str-opts($_)>><?.<value>.defined()><.value></?></textarea>
         <&control-help($_, :$help-class)>
         <&control-validation-message($_, :$invalid-feedback-class)>
       </div>
@@ -102,7 +102,7 @@
     <?{ .type eq 'select' }>
       <div<&class($input-group-class)>>
         <label for="<.name>"<&class($input-label-class)>><.label></label>
-        <select <?.multi>multiple</?> name="<.name>" id="<.name>"<&control-class($_, $input-control-class, :$is-invalid-class)>>
+        <select <?.multi>multiple</?> name="<.name>" id="<.name>"<?.required>required</?><&control-class($_, $input-control-class, :$is-invalid-class)>>
           <@options : $opt>
             <option value="<$opt.[0]>"<?{ $opt.[2] }> selected="selected"</?>><$opt.[1]></option>
           </@>


### PR DESCRIPTION
Resolves issue #99

While all the declaration and validation logic supports wiring up the `is required` attribute trait, including the output of this state in the method HTML-RENDER-DATA result, this is not handled in the prelude.crotmp template.

My best guess is that this was forgotten by the original authors and that my work on Air::Form is the first deep use of Cro::WebApp::Form.

I have tested this code and all the tests pass. I have also checked operation with / without the HTML `novolidate` form tag attribute and it works correctly in both browser side validation (Chrome only) and server side validation.

